### PR TITLE
update mruby-mix, add build_config.rb.lock

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
           cache-revision: 1
         with:
           path: ${{ github.workspace }}/mruby/build/
-          key: ${{ hashFiles('build_config.rb') }}-${{ hashFiles('.git/modules/mruby/HEAD') }}-${{ matrix.xcode }}-${{ env.cache-revision }}
+          key: ${{ hashFiles('build_config.rb') }}-${{ hashFiles('build_config.rb.lock') }}-${{ hashFiles('.git/modules/mruby/HEAD') }}-${{ matrix.xcode }}-${{ env.cache-revision }}
 
       - name: Build
         run: xcodebuild -workspace Cocotodon.xcworkspace -scheme Cocotodon clean archive -archivePath build/Cocotodon.xcarchive

--- a/build_config.rb
+++ b/build_config.rb
@@ -1,8 +1,6 @@
 # disable pkg-config
 ENV['PKG_CONFIG_LIBDIR'] = ''
 
-MRuby::Lockfile.disable
-
 shared = ->(conf) do
   conf.cc.defines << %w(MRB_UTF8_STRING)
 

--- a/build_config.rb.lock
+++ b/build_config.rb.lock
@@ -1,0 +1,380 @@
+---
+mruby_version:
+  version: 2.1.2
+  release_no: 20102
+builds:
+  host:
+    https://github.com/mrbgems/mruby-yaml.git:
+      url: https://github.com/mrbgems/mruby-yaml.git
+      branch: HEAD
+      commit: 0606652a6e99d902cd3101cf2d757a7c0c37a7fd
+      version: 0.1.0
+    https://github.com/shibafu528/mruby-mix.git:
+      url: https://github.com/shibafu528/mruby-mix.git
+      branch: HEAD
+      commit: b793088a7a9eed6e2ab74d886d5d0d0dd9fed4b1
+    https://github.com/shibafu528/mruby-set.git:
+      url: https://github.com/shibafu528/mruby-set.git
+      branch: my-dev
+      commit: 9f31599368946758d31f12459aa62ce760a030c4
+      version: 0.0.0
+    https://github.com/shibafu528/mruby-pluggaloid.git:
+      url: https://github.com/shibafu528/mruby-pluggaloid.git
+      branch: mruby
+      commit: 43129a187c9c9f336f35174ead6972f0aabf933e
+      version: 1.5.0
+    https://github.com/shibafu528/mruby-diva.git:
+      url: https://github.com/shibafu528/mruby-diva.git
+      branch: mruby
+      commit: 63299e5a3183dcd51788196b919b1812b9f02a8f
+      version: 1.0.2
+    https://github.com/shibafu528/mruby-delayer-deferred.git:
+      url: https://github.com/shibafu528/mruby-delayer-deferred.git
+      branch: mruby
+      commit: c3bc0ef77aad9c942800f346408004477cbc7446
+      version: 2.2.0
+    https://github.com/ksss/mruby-singleton.git:
+      url: https://github.com/ksss/mruby-singleton.git
+      branch: master
+      commit: 73dd4bae1a47d82e49b8f85bf27f49ec4462052e
+      version: 0.0.0
+    https://github.com/mattn/mruby-require.git:
+      url: https://github.com/mattn/mruby-require.git
+      branch: HEAD
+      commit: b2b95a27b8658c46c5cb05abd168e77a12aef2a4
+      version: 0.0.0
+    https://github.com/iij/mruby-dir.git:
+      url: https://github.com/iij/mruby-dir.git
+      branch: master
+      commit: 89dceefa1250fb1ae868d4cb52498e9e24293cd1
+      version: 0.0.0
+    https://github.com/shibafu528/mruby-delayer.git:
+      url: https://github.com/shibafu528/mruby-delayer.git
+      branch: mruby
+      commit: b20de4b3c6d6b3c2e86157fb51411f06ae6c0d6b
+      version: 1.1.2
+    https://github.com/shibafu528/mruby-instance-storage.git:
+      url: https://github.com/shibafu528/mruby-instance-storage.git
+      branch: master
+      commit: d11690a510ddaf3559328cb78c1b81cd7260e152
+      version: 1.0.0
+    https://github.com/IceDragon200/mruby-catch-throw:
+      url: https://github.com/IceDragon200/mruby-catch-throw
+      branch: master
+      commit: 2b6eaff4232b4a9473b864df53c2917080af5dcf
+      version: 1.1.0
+    https://github.com/monochromegane/mruby-secure-random.git:
+      url: https://github.com/monochromegane/mruby-secure-random.git
+      branch: master
+      commit: 4971702e8cd299054b3220b4adb6bc3031ae2881
+      version: 0.0.0
+    https://github.com/zzak/mruby-uri.git:
+      url: https://github.com/zzak/mruby-uri.git
+      branch: master
+      commit: b3108ae56a48990eb7b79f44aca4ec76e1e60ad8
+      version: 0.0.0
+    https://github.com/mattn/mruby-onig-regexp.git:
+      url: https://github.com/mattn/mruby-onig-regexp.git
+      branch: master
+      commit: 20ba3325d6fa504cbbf193e1b2a90e20fdab544f
+      version: 0.0.0
+  macos-x86_64-debug:
+    https://github.com/mrbgems/mruby-yaml.git:
+      url: https://github.com/mrbgems/mruby-yaml.git
+      branch: HEAD
+      commit: 0606652a6e99d902cd3101cf2d757a7c0c37a7fd
+      version: 0.1.0
+    https://github.com/shibafu528/mruby-mix.git:
+      url: https://github.com/shibafu528/mruby-mix.git
+      branch: HEAD
+      commit: b793088a7a9eed6e2ab74d886d5d0d0dd9fed4b1
+    https://github.com/shibafu528/mruby-set.git:
+      url: https://github.com/shibafu528/mruby-set.git
+      branch: my-dev
+      commit: 9f31599368946758d31f12459aa62ce760a030c4
+      version: 0.0.0
+    https://github.com/shibafu528/mruby-pluggaloid.git:
+      url: https://github.com/shibafu528/mruby-pluggaloid.git
+      branch: mruby
+      commit: 43129a187c9c9f336f35174ead6972f0aabf933e
+      version: 1.5.0
+    https://github.com/shibafu528/mruby-diva.git:
+      url: https://github.com/shibafu528/mruby-diva.git
+      branch: mruby
+      commit: 63299e5a3183dcd51788196b919b1812b9f02a8f
+      version: 1.0.2
+    https://github.com/shibafu528/mruby-delayer-deferred.git:
+      url: https://github.com/shibafu528/mruby-delayer-deferred.git
+      branch: mruby
+      commit: c3bc0ef77aad9c942800f346408004477cbc7446
+      version: 2.2.0
+    https://github.com/ksss/mruby-singleton.git:
+      url: https://github.com/ksss/mruby-singleton.git
+      branch: master
+      commit: 73dd4bae1a47d82e49b8f85bf27f49ec4462052e
+      version: 0.0.0
+    https://github.com/mattn/mruby-require.git:
+      url: https://github.com/mattn/mruby-require.git
+      branch: HEAD
+      commit: b2b95a27b8658c46c5cb05abd168e77a12aef2a4
+      version: 0.0.0
+    https://github.com/iij/mruby-dir.git:
+      url: https://github.com/iij/mruby-dir.git
+      branch: master
+      commit: 89dceefa1250fb1ae868d4cb52498e9e24293cd1
+      version: 0.0.0
+    https://github.com/shibafu528/mruby-delayer.git:
+      url: https://github.com/shibafu528/mruby-delayer.git
+      branch: mruby
+      commit: b20de4b3c6d6b3c2e86157fb51411f06ae6c0d6b
+      version: 1.1.2
+    https://github.com/shibafu528/mruby-instance-storage.git:
+      url: https://github.com/shibafu528/mruby-instance-storage.git
+      branch: master
+      commit: d11690a510ddaf3559328cb78c1b81cd7260e152
+      version: 1.0.0
+    https://github.com/IceDragon200/mruby-catch-throw:
+      url: https://github.com/IceDragon200/mruby-catch-throw
+      branch: master
+      commit: 2b6eaff4232b4a9473b864df53c2917080af5dcf
+      version: 1.1.0
+    https://github.com/monochromegane/mruby-secure-random.git:
+      url: https://github.com/monochromegane/mruby-secure-random.git
+      branch: master
+      commit: 4971702e8cd299054b3220b4adb6bc3031ae2881
+      version: 0.0.0
+    https://github.com/zzak/mruby-uri.git:
+      url: https://github.com/zzak/mruby-uri.git
+      branch: master
+      commit: b3108ae56a48990eb7b79f44aca4ec76e1e60ad8
+      version: 0.0.0
+    https://github.com/mattn/mruby-onig-regexp.git:
+      url: https://github.com/mattn/mruby-onig-regexp.git
+      branch: master
+      commit: 20ba3325d6fa504cbbf193e1b2a90e20fdab544f
+      version: 0.0.0
+  macos-x86_64-release:
+    https://github.com/mrbgems/mruby-yaml.git:
+      url: https://github.com/mrbgems/mruby-yaml.git
+      branch: HEAD
+      commit: 0606652a6e99d902cd3101cf2d757a7c0c37a7fd
+      version: 0.1.0
+    https://github.com/shibafu528/mruby-mix.git:
+      url: https://github.com/shibafu528/mruby-mix.git
+      branch: HEAD
+      commit: b793088a7a9eed6e2ab74d886d5d0d0dd9fed4b1
+    https://github.com/shibafu528/mruby-set.git:
+      url: https://github.com/shibafu528/mruby-set.git
+      branch: my-dev
+      commit: 9f31599368946758d31f12459aa62ce760a030c4
+      version: 0.0.0
+    https://github.com/shibafu528/mruby-pluggaloid.git:
+      url: https://github.com/shibafu528/mruby-pluggaloid.git
+      branch: mruby
+      commit: 43129a187c9c9f336f35174ead6972f0aabf933e
+      version: 1.5.0
+    https://github.com/shibafu528/mruby-diva.git:
+      url: https://github.com/shibafu528/mruby-diva.git
+      branch: mruby
+      commit: 63299e5a3183dcd51788196b919b1812b9f02a8f
+      version: 1.0.2
+    https://github.com/shibafu528/mruby-delayer-deferred.git:
+      url: https://github.com/shibafu528/mruby-delayer-deferred.git
+      branch: mruby
+      commit: c3bc0ef77aad9c942800f346408004477cbc7446
+      version: 2.2.0
+    https://github.com/ksss/mruby-singleton.git:
+      url: https://github.com/ksss/mruby-singleton.git
+      branch: master
+      commit: 73dd4bae1a47d82e49b8f85bf27f49ec4462052e
+      version: 0.0.0
+    https://github.com/mattn/mruby-require.git:
+      url: https://github.com/mattn/mruby-require.git
+      branch: HEAD
+      commit: b2b95a27b8658c46c5cb05abd168e77a12aef2a4
+      version: 0.0.0
+    https://github.com/iij/mruby-dir.git:
+      url: https://github.com/iij/mruby-dir.git
+      branch: master
+      commit: 89dceefa1250fb1ae868d4cb52498e9e24293cd1
+      version: 0.0.0
+    https://github.com/shibafu528/mruby-delayer.git:
+      url: https://github.com/shibafu528/mruby-delayer.git
+      branch: mruby
+      commit: b20de4b3c6d6b3c2e86157fb51411f06ae6c0d6b
+      version: 1.1.2
+    https://github.com/shibafu528/mruby-instance-storage.git:
+      url: https://github.com/shibafu528/mruby-instance-storage.git
+      branch: master
+      commit: d11690a510ddaf3559328cb78c1b81cd7260e152
+      version: 1.0.0
+    https://github.com/IceDragon200/mruby-catch-throw:
+      url: https://github.com/IceDragon200/mruby-catch-throw
+      branch: master
+      commit: 2b6eaff4232b4a9473b864df53c2917080af5dcf
+      version: 1.1.0
+    https://github.com/monochromegane/mruby-secure-random.git:
+      url: https://github.com/monochromegane/mruby-secure-random.git
+      branch: master
+      commit: 4971702e8cd299054b3220b4adb6bc3031ae2881
+      version: 0.0.0
+    https://github.com/zzak/mruby-uri.git:
+      url: https://github.com/zzak/mruby-uri.git
+      branch: master
+      commit: b3108ae56a48990eb7b79f44aca4ec76e1e60ad8
+      version: 0.0.0
+    https://github.com/mattn/mruby-onig-regexp.git:
+      url: https://github.com/mattn/mruby-onig-regexp.git
+      branch: master
+      commit: 20ba3325d6fa504cbbf193e1b2a90e20fdab544f
+      version: 0.0.0
+  macos-arm64-debug:
+    https://github.com/mrbgems/mruby-yaml.git:
+      url: https://github.com/mrbgems/mruby-yaml.git
+      branch: HEAD
+      commit: 0606652a6e99d902cd3101cf2d757a7c0c37a7fd
+      version: 0.1.0
+    https://github.com/shibafu528/mruby-mix.git:
+      url: https://github.com/shibafu528/mruby-mix.git
+      branch: HEAD
+      commit: b793088a7a9eed6e2ab74d886d5d0d0dd9fed4b1
+    https://github.com/shibafu528/mruby-set.git:
+      url: https://github.com/shibafu528/mruby-set.git
+      branch: my-dev
+      commit: 9f31599368946758d31f12459aa62ce760a030c4
+      version: 0.0.0
+    https://github.com/shibafu528/mruby-pluggaloid.git:
+      url: https://github.com/shibafu528/mruby-pluggaloid.git
+      branch: mruby
+      commit: 43129a187c9c9f336f35174ead6972f0aabf933e
+      version: 1.5.0
+    https://github.com/shibafu528/mruby-diva.git:
+      url: https://github.com/shibafu528/mruby-diva.git
+      branch: mruby
+      commit: 63299e5a3183dcd51788196b919b1812b9f02a8f
+      version: 1.0.2
+    https://github.com/shibafu528/mruby-delayer-deferred.git:
+      url: https://github.com/shibafu528/mruby-delayer-deferred.git
+      branch: mruby
+      commit: c3bc0ef77aad9c942800f346408004477cbc7446
+      version: 2.2.0
+    https://github.com/ksss/mruby-singleton.git:
+      url: https://github.com/ksss/mruby-singleton.git
+      branch: master
+      commit: 73dd4bae1a47d82e49b8f85bf27f49ec4462052e
+      version: 0.0.0
+    https://github.com/mattn/mruby-require.git:
+      url: https://github.com/mattn/mruby-require.git
+      branch: HEAD
+      commit: b2b95a27b8658c46c5cb05abd168e77a12aef2a4
+      version: 0.0.0
+    https://github.com/iij/mruby-dir.git:
+      url: https://github.com/iij/mruby-dir.git
+      branch: master
+      commit: 89dceefa1250fb1ae868d4cb52498e9e24293cd1
+      version: 0.0.0
+    https://github.com/shibafu528/mruby-delayer.git:
+      url: https://github.com/shibafu528/mruby-delayer.git
+      branch: mruby
+      commit: b20de4b3c6d6b3c2e86157fb51411f06ae6c0d6b
+      version: 1.1.2
+    https://github.com/shibafu528/mruby-instance-storage.git:
+      url: https://github.com/shibafu528/mruby-instance-storage.git
+      branch: master
+      commit: d11690a510ddaf3559328cb78c1b81cd7260e152
+      version: 1.0.0
+    https://github.com/IceDragon200/mruby-catch-throw:
+      url: https://github.com/IceDragon200/mruby-catch-throw
+      branch: master
+      commit: 2b6eaff4232b4a9473b864df53c2917080af5dcf
+      version: 1.1.0
+    https://github.com/monochromegane/mruby-secure-random.git:
+      url: https://github.com/monochromegane/mruby-secure-random.git
+      branch: master
+      commit: 4971702e8cd299054b3220b4adb6bc3031ae2881
+      version: 0.0.0
+    https://github.com/zzak/mruby-uri.git:
+      url: https://github.com/zzak/mruby-uri.git
+      branch: master
+      commit: b3108ae56a48990eb7b79f44aca4ec76e1e60ad8
+      version: 0.0.0
+    https://github.com/mattn/mruby-onig-regexp.git:
+      url: https://github.com/mattn/mruby-onig-regexp.git
+      branch: master
+      commit: 20ba3325d6fa504cbbf193e1b2a90e20fdab544f
+      version: 0.0.0
+  macos-arm64-release:
+    https://github.com/mrbgems/mruby-yaml.git:
+      url: https://github.com/mrbgems/mruby-yaml.git
+      branch: HEAD
+      commit: 0606652a6e99d902cd3101cf2d757a7c0c37a7fd
+      version: 0.1.0
+    https://github.com/shibafu528/mruby-mix.git:
+      url: https://github.com/shibafu528/mruby-mix.git
+      branch: HEAD
+      commit: b793088a7a9eed6e2ab74d886d5d0d0dd9fed4b1
+    https://github.com/shibafu528/mruby-set.git:
+      url: https://github.com/shibafu528/mruby-set.git
+      branch: my-dev
+      commit: 9f31599368946758d31f12459aa62ce760a030c4
+      version: 0.0.0
+    https://github.com/shibafu528/mruby-pluggaloid.git:
+      url: https://github.com/shibafu528/mruby-pluggaloid.git
+      branch: mruby
+      commit: 43129a187c9c9f336f35174ead6972f0aabf933e
+      version: 1.5.0
+    https://github.com/shibafu528/mruby-diva.git:
+      url: https://github.com/shibafu528/mruby-diva.git
+      branch: mruby
+      commit: 63299e5a3183dcd51788196b919b1812b9f02a8f
+      version: 1.0.2
+    https://github.com/shibafu528/mruby-delayer-deferred.git:
+      url: https://github.com/shibafu528/mruby-delayer-deferred.git
+      branch: mruby
+      commit: c3bc0ef77aad9c942800f346408004477cbc7446
+      version: 2.2.0
+    https://github.com/ksss/mruby-singleton.git:
+      url: https://github.com/ksss/mruby-singleton.git
+      branch: master
+      commit: 73dd4bae1a47d82e49b8f85bf27f49ec4462052e
+      version: 0.0.0
+    https://github.com/mattn/mruby-require.git:
+      url: https://github.com/mattn/mruby-require.git
+      branch: HEAD
+      commit: b2b95a27b8658c46c5cb05abd168e77a12aef2a4
+      version: 0.0.0
+    https://github.com/iij/mruby-dir.git:
+      url: https://github.com/iij/mruby-dir.git
+      branch: master
+      commit: 89dceefa1250fb1ae868d4cb52498e9e24293cd1
+      version: 0.0.0
+    https://github.com/shibafu528/mruby-delayer.git:
+      url: https://github.com/shibafu528/mruby-delayer.git
+      branch: mruby
+      commit: b20de4b3c6d6b3c2e86157fb51411f06ae6c0d6b
+      version: 1.1.2
+    https://github.com/shibafu528/mruby-instance-storage.git:
+      url: https://github.com/shibafu528/mruby-instance-storage.git
+      branch: master
+      commit: d11690a510ddaf3559328cb78c1b81cd7260e152
+      version: 1.0.0
+    https://github.com/IceDragon200/mruby-catch-throw:
+      url: https://github.com/IceDragon200/mruby-catch-throw
+      branch: master
+      commit: 2b6eaff4232b4a9473b864df53c2917080af5dcf
+      version: 1.1.0
+    https://github.com/monochromegane/mruby-secure-random.git:
+      url: https://github.com/monochromegane/mruby-secure-random.git
+      branch: master
+      commit: 4971702e8cd299054b3220b4adb6bc3031ae2881
+      version: 0.0.0
+    https://github.com/zzak/mruby-uri.git:
+      url: https://github.com/zzak/mruby-uri.git
+      branch: master
+      commit: b3108ae56a48990eb7b79f44aca4ec76e1e60ad8
+      version: 0.0.0
+    https://github.com/mattn/mruby-onig-regexp.git:
+      url: https://github.com/mattn/mruby-onig-regexp.git
+      branch: master
+      commit: 20ba3325d6fa504cbbf193e1b2a90e20fdab544f
+      version: 0.0.0


### PR DESCRIPTION
masterのCIがおかしくなっていたので原因を調べたところ、間接依存mrbgemであるmruby-requireがmrubyの開発版にしか存在しないヘッダーファイルをincludeするようになっていた。

mruby 3.1.0に存在するならバージョン上げて対応しようと思ったのだが、まだタグが打たれていない開発版のみの要素だったので、mruby-mix側にgemバージョン固定のコミットを入れて対応した。  
(本当はこういう対応をするのは良くない、あとでrevertしたい……)

また、Cocotodonにはbuild_config.rb.lockが入っていないことに気づいたので、今後は含めるようにしてCI時にチェックアウトされるmrbgemのリビジョンが固定されるよう願うことにした。